### PR TITLE
 ENG-8456: fix a IndexOutOfBound error caused by negative hash id

### DIFF
--- a/src/main/java/org/voltdb/exportclient/hive/HiveSink.java
+++ b/src/main/java/org/voltdb/exportclient/hive/HiveSink.java
@@ -65,7 +65,7 @@ public class HiveSink {
     }
 
     ListenableFuture<?> asWriteTask(final HiveEndPoint endPoint, final Collection<String> records) {
-        final int hashed = endPoint.partitionVals.hashCode() % HIVE_CONCURRENT_WRITERS;
+        final int hashed = ((endPoint.partitionVals.hashCode() % HIVE_CONCURRENT_WRITERS) + HIVE_CONCURRENT_WRITERS) % HIVE_CONCURRENT_WRITERS; // Always return non negative modulus [0..HHIVE_CONCURRENT_WRITERS-1]
         if (m_executors.get(hashed).isShutdown()) {
             return Futures.immediateFailedFuture(new HiveExportException("hive sink executor is shut down"));
         }

--- a/src/main/java/org/voltdb/exportclient/hive/HiveSink.java
+++ b/src/main/java/org/voltdb/exportclient/hive/HiveSink.java
@@ -65,7 +65,7 @@ public class HiveSink {
     }
 
     ListenableFuture<?> asWriteTask(final HiveEndPoint endPoint, final Collection<String> records) {
-        final int hashed = ((endPoint.partitionVals.hashCode() % HIVE_CONCURRENT_WRITERS) + HIVE_CONCURRENT_WRITERS) % HIVE_CONCURRENT_WRITERS; // Always return non negative modulus [0..HHIVE_CONCURRENT_WRITERS-1]
+        final int hashed = Math.abs(endPoint.partitionVals.hashCode() % HIVE_CONCURRENT_WRITERS);
         if (m_executors.get(hashed).isShutdown()) {
             return Futures.immediateFailedFuture(new HiveExportException("hive sink executor is shut down"));
         }


### PR DESCRIPTION
Variable hashed should be non-negative.
Instead of simply abs the value, this fix will return a correct non-negative mod value.
